### PR TITLE
Support UTF-8 Encoded Command-Line Arguments

### DIFF
--- a/src/argv_ffi.erl
+++ b/src/argv_ffi.erl
@@ -4,7 +4,9 @@
 
 load() ->
     Runtime = <<(stringarg(bindir))/binary, "/", (stringarg(progname))/binary>>,
-    PlainArguments = lists:map(fun list_to_binary/1, init:get_plain_arguments()),
+    PlainArguments = lists:map(
+        fun(Arg) -> unicode:characters_to_binary(Arg, utf8) end, init:get_plain_arguments()
+    ),
     {Program, Arguments} = case init:get_argument(escript) of
         % We're in an escript, so the first argument is the executable name
         {ok, _} ->
@@ -14,7 +16,7 @@ load() ->
         % We're not in a escript. Assume the cwd is the project root.
         _ ->
             {ok, Cwd} = file:get_cwd(),
-            {list_to_binary(Cwd), PlainArguments}
+            {unicode:characters_to_binary(Cwd, utf8), PlainArguments}
     end,
     {Runtime, Program, Arguments}.
 


### PR DESCRIPTION
This pull request introduces changes to properly handle UTF-8 encoded command-line arguments and current working directory paths in the application. The modifications ensure that multibyte character strings, such as Japanese, are correctly processed and converted into UTF-8 encoded binaries.

## Example

```gleam
import gleam/io
import argv

pub fn main() {
  argv.load()
  |> io.debug()
}
```

Note: Some of the paths included in the output have been edited for clarity and privacy.

### Argument in UTF-8 characters

Before: 

```shell
> gleam run こんにちは
exception error: bad argument
  in function  list_to_binary/1
     called as list_to_binary([12371,12435,12395,12385,12399])
     *** argument 1: not an iolist term
  in call from argv_ffi:'-load/0-fun-0-'/1 (/path/to/project/build/dev/erlang/argv/_gleam_artefacts/argv_ffi.erl, line 7)
  in call from lists:map/2 (lists.erl, line 1559)
  in call from argv_ffi:load/0 (/path/to/project/build/dev/erlang/argv/_gleam_artefacts/argv_ffi.erl, line 7)
  in call from argv:load/0 (/path/to/project/build/dev/erlang/argv/_gleam_artefacts/argv.erl, line 11)
  in call from argv_test:main/0 (/path/to/project/build/dev/erlang/argv_test/_gleam_artefacts/argv_test.erl, line 8)%    
```

After:

```shell
> gleam run こんにちは
Argv("/opt/homebrew/Cellar/erlang/26.2.2/lib/erlang/erts-14.2.2/bin/erl", "/path/to/project", ["こんにちは"])
```

### Path including UTF-8 characters

Before:

```shell
> gleam run  
exception error: bad argument
  in function  list_to_binary/1
     called as list_to_binary([47, 112, 97, 116, 104, 47, 116, 111, 47, 
                                 12371, 12435, 12395, 12385, 12399, 47, 112, 
                                  114, 111, 106, 101, 99, 116])
     *** argument 1: not an iolist term
  in call from argv_ffi:load/0 (/path/to/こんにちは/project/build/dev/erlang/argv/_gleam_artefacts/argv_ffi.erl, line 17)
  in call from argv:load/0 (/path/to/こんにちは/project/build/dev/erlang/argv/_gleam_artefacts/argv.erl, line 11)
  in call from argv_test:main/0 (/path/to/こんにちは/project/build/dev/erlang/argv_test/_gleam_artefacts/argv_test.erl, line 8)
```

After:

```shell
> gleam run
Argv("/opt/homebrew/Cellar/erlang/26.2.2/lib/erlang/erts-14.2.2/bin/erl", "/path/to/こんにちは/project", [])
```