### PR TITLE
Fix arguments when using `-e` with Node.js or Bun

### DIFF
--- a/src/argv_ffi.mjs
+++ b/src/argv_ffi.mjs
@@ -10,8 +10,9 @@ export function load() {
 
   if (globalThis.process) {
     const specialArgs = ["-e", "--eval", "-p", "--print"];
-    // In Node.js and Bun, when special arguments are specified, `process.argv[1]` is not a script path,
-    // and command line arguments are stored starting from `process.argv[1]`.
+    // In Node.js and Bun, when special arguments are specified,
+    // `process.argv[1]` is not a script path, and command line arguments
+    // are stored starting from `process.argv[1]`.
     if (process.execArgv.some((x) => specialArgs.includes(x))) {
       const [runtime, ...args] = process.argv;
       return [runtime, "", List.fromArray(args)];

--- a/src/argv_ffi.mjs
+++ b/src/argv_ffi.mjs
@@ -1,16 +1,24 @@
 import { List } from "./gleam.mjs";
 
 export function load() {
-  if (globalThis.process) {
-    const [runtime, program, ...args] = process.argv;
-    return [runtime, program, List.fromArray(args)];
-  }
-
   if (globalThis.Deno) {
     const runtime = Deno.execPath();
     const program = new URL(Deno.mainModule).pathname;
     const args = List.fromArray(Deno.args);
     return [runtime, program, args];
+  }
+
+  if (globalThis.process) {
+    const specialArgs = ["-e", "--eval", "-p", "--print"];
+    // In Node.js and Bun, when special arguments are specified, `process.argv[1]` is not a script path,
+    // and command line arguments are stored starting from `process.argv[1]`.
+    if (process.execArgv.some((x) => specialArgs.includes(x))) {
+      const [runtime, ...args] = process.argv;
+      return [runtime, "", List.fromArray(args)];
+    } else {
+      const [runtime, program, ...args] = process.argv;
+      return [runtime, program, List.fromArray(args)];
+    }
   }
 
   const runtime = "browser";


### PR DESCRIPTION
Fix arguments when using special arguments (i.e. `-e`, `--eval`, `-p`, `--print`) with Node.js or Bun.

When special arguments are specified, `process.argv[1]` is not a script path, and command line arguments are stored starting from `process.argv[1]`.
In Node.js, `util.parseArgs()`, which parses `process.argv`, extracts from index 1 of `process.argv` when a special argument is specified.
https://github.com/nodejs/node/blob/7079041e0a73738185ff5b7480d4775158b527c3/lib/internal/util/parse_args/parse_args.js#L58-L72

Deno also implements `process.argv`, but it behaves differently from Node.js and Bun.
Therefore, change the processing order so that `Deno.args` takes precedence over `process.argv`.

## Before this change

### Node.js

When executing as Node.js script file, an argument `arg1` is included in `arguments`.

```sh
echo "import {load} from './build/dev/javascript/argv/argv.mjs'; console.log(load())" >main.mjs && node main.mjs arg1
```

Output:
```
Argv {
  runtime: '/home/kit494way/.local/share/mise/installs/node/24.2.0/bin/node',
  program: '/home/kit494way/projects/argv/main.mjs',
  arguments: NonEmpty { head: 'arg1', tail: Empty {} }
}
```

When evaluating string as Node.js script, an arguments `arg1` is treated as `program` and not included in `arguments`.

```sh
node -e "import {load} from './build/dev/javascript/argv/argv.mjs'; console.log(load())" arg1
```

Output:
```
Argv {
  runtime: '/home/kit494way/.local/share/mise/installs/node/24.2.0/bin/node',
  program: 'arg1',
  arguments: Empty {}
}
```

### Bun

When executing as Bun script file, an argument `arg1` is included in `arguments`.

```sh
echo "import {load} from './build/dev/javascript/argv/argv.mjs'; console.log(load())" >main.mjs && bun main.mjs arg1
```

Output:
```
Argv {
  runtime: "/home/kit494way/.local/share/mise/installs/bun/1.2.16/bin/bun",
  program: "/home/kit494way/projects/argv/main.mjs",
  arguments: NonEmpty {
    head: "arg1",
    tail: Empty {
      toArray: [Function: toArray],
      atLeastLength: [Function: atLeastLength],
      hasLength: [Function: hasLength],
      countLength: [Function: countLength],
      [Symbol(Symbol.iterator)]: [Function],
    },
    toArray: [Function: toArray],
    atLeastLength: [Function: atLeastLength],
    hasLength: [Function: hasLength],
    countLength: [Function: countLength],
    [Symbol(Symbol.iterator)]: [Function],
  },
  withFields: [Function: withFields],
}
```

When evaluating string as Bun script, an arguments `arg1` is treated as `program` and not included in `arguments`.

```sh
bun -e "import {load} from './build/dev/javascript/argv/argv.mjs'; console.log(load())" arg1
```

Output:
```
Argv {
  runtime: "/home/kit494way/.local/share/mise/installs/bun/1.2.16/bin/bun",
  program: "arg1",
  arguments: Empty {
    toArray: [Function: toArray],
    atLeastLength: [Function: atLeastLength],
    hasLength: [Function: hasLength],
    countLength: [Function: countLength],
    [Symbol(Symbol.iterator)]: [Function],
  },
  withFields: [Function: withFields],
}
```

## After this change

### Node.js

Regardless of whether you execute it as a script file or evaluate a string as a script, the argument `arg1` is correctly included in `arguments`.

Execute as Node.js script file:
```sh
echo "import {load} from './build/dev/javascript/argv/argv.mjs'; console.log(load())" >main.mjs && node main.mjs arg1
```

Output:
```
Argv {
  runtime: '/home/kit494way/.local/share/mise/installs/node/24.2.0/bin/node',
  program: '/home/kit494way/projects/argv/main.mjs',
  arguments: NonEmpty { head: 'arg1', tail: Empty {} }
}
```

Evaluate string as Node.js script:
```sh
node -e "import {load} from './build/dev/javascript/argv/argv.mjs'; console.log(load())" arg1
```

Output:
```
Argv {
  runtime: '/home/kit494way/.local/share/mise/installs/node/24.2.0/bin/node',
  program: '',
  arguments: NonEmpty { head: 'arg1', tail: Empty {} }
}
```

### Bun

Regardless of whether you execute it as a script file or evaluate a string as a script, the argument `arg1` is correctly included in `arguments`.

Execute as Bun script file:
```sh
echo "import {load} from './build/dev/javascript/argv/argv.mjs'; console.log(load())" >main.mjs && bun main.mjs arg1
```

Output:
```
Argv {
  runtime: "/home/kit494way/.local/share/mise/installs/bun/1.2.16/bin/bun",
  program: "/home/kit494way/projects/argv/main.mjs",
  arguments: NonEmpty {
    head: "arg1",
    tail: Empty {
      toArray: [Function: toArray],
      atLeastLength: [Function: atLeastLength],
      hasLength: [Function: hasLength],
      countLength: [Function: countLength],
      [Symbol(Symbol.iterator)]: [Function],
    },
    toArray: [Function: toArray],
    atLeastLength: [Function: atLeastLength],
    hasLength: [Function: hasLength],
    countLength: [Function: countLength],
    [Symbol(Symbol.iterator)]: [Function],
  },
  withFields: [Function: withFields],
}
```

Evaluate string as Bun script:
```sh
bun -e "import {load} from './build/dev/javascript/argv/argv.mjs'; console.log(load())" arg1
```

Output:
```
Argv {
  runtime: "/home/kit494way/.local/share/mise/installs/bun/1.2.16/bin/bun",
  program: "",
  arguments: NonEmpty {
    head: "arg1",
    tail: Empty {
      toArray: [Function: toArray],
      atLeastLength: [Function: atLeastLength],
      hasLength: [Function: hasLength],
      countLength: [Function: countLength],
      [Symbol(Symbol.iterator)]: [Function],
    },
    toArray: [Function: toArray],
    atLeastLength: [Function: atLeastLength],
    hasLength: [Function: hasLength],
    countLength: [Function: countLength],
    [Symbol(Symbol.iterator)]: [Function],
  },
  withFields: [Function: withFields],
}
```