### PR TITLE
Update gleam_stdlib to allow for 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## NEXT
+
+- Updated dependency specification to allow for `gleam_stdlib` 1.0.
+
 ## v1.0.1 - 2023-12-26
 
 - The type of the `arguments` field has been corrected.

--- a/gleam.toml
+++ b/gleam.toml
@@ -12,4 +12,4 @@ links = [
 allow_read = true
 
 [dev-dependencies]
-gleam_stdlib = "~> 0.32"
+gleam_stdlib = "~> 0.32 or ~> 1.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,8 +2,8 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "0.34.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "1FB8454D2991E9B4C0C804544D8A9AD0F6184725E20D63C3155F0AEB4230B016" },
+  { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
 ]
 
 [requirements]
-gleam_stdlib = { version = "~> 0.32" }
+gleam_stdlib = { version = "~> 0.32 or ~> 1.0" }

--- a/test/argv_test.gleam
+++ b/test/argv_test.gleam
@@ -1,8 +1,7 @@
-import gleam/io
 import argv
 
 pub fn main() {
   let argv = argv.load()
-  io.debug(argv)
+  echo argv
   let assert [] = argv.load().arguments
 }


### PR DESCRIPTION

This is still kept very broad as there are many applications that haven't upgraded to stdlib 1.0, but now argv wlll not prevent it.